### PR TITLE
Fix incorrect usage of try() in estimate.default: use silent=TRUE

### DIFF
--- a/R/estimate.default.R
+++ b/R/estimate.default.R
@@ -288,7 +288,7 @@ estimate.default <- function(x=NULL, f=NULL, ..., data, id,
   if (!missing(coef)) {
     pp <- coef
   } else {
-    pp <- suppressWarnings(try(stats::coef(x), "try-error"))
+    pp <- suppressWarnings(try(stats::coef(x), silent = TRUE))
     if (inherits(x, "survreg") && length(pp) < NROW(x$var)) {
       pp <- c(pp, scale=x$scale)
     }


### PR DESCRIPTION
# Description:
This PR fixes a non-standard usage of the try() function in R/estimate.default.R.
The previous code:
`pp <- suppressWarnings(try(stats::coef(x), "try-error"))`
caused the following error: 
`Error in !silent : invalid argument type`
The correct code is:
`pp <- suppressWarnings(try(stats::coef(x), silent = TRUE))`

