### PR TITLE
fix: code quality improvements and minor bug fixes

### DIFF
--- a/R/children.R
+++ b/R/children.R
@@ -35,7 +35,7 @@ edgeList.lvmfit <- function(object,...) edgeList(Model(object),...)
 edgeList.lvm <- function(object, labels=FALSE, list=FALSE, ...) {
     edgelist <- data.frame(from=NULL,to=NULL)
     A <- adjMat(object)
-    for (i in 1:nrow(A)) {
+    for (i in seq_len(nrow(A))) {
         ii <- which(A[,i]>0)
         if (length(ii)>0)
             edgelist <- rbind(edgelist,data.frame(from=ii,to=i))

--- a/R/complik.R
+++ b/R/complik.R
@@ -34,7 +34,7 @@ complik <- function(x, data, k=2, type=c("all","nearest"), pairlist,
 
     y <- setdiff(endogenous(x),latent(x))
     binsurv <- rep(FALSE,length(y))
-    for (i in 1:length(y)) {
+    for (i in seq_along(y)) {
         z <- try(data[,y[i]],silent=TRUE)
         ## binsurv[i] <- is.Surv(z) | (is.factor(z) && length(levels(z))==2)
         if (!inherits(z,"try-error"))
@@ -68,7 +68,7 @@ complik <- function(x, data, k=2, type=c("all","nearest"), pairlist,
     mydata0 <- data[,,drop=FALSE]
     mydata <-  as.data.frame(matrix(NA, nblocks*nrow(data), ncol=ncol(data)))
     names(mydata) <- names(mydata0)
-    for (i in 1:ncol(mydata)) {
+    for (i in seq_len(ncol(mydata))) {
         if (is.factor(data[,i])) {
             mydata[,i] <- factor(mydata[,i],levels=levels(mydata0[,i]))
         }
@@ -91,7 +91,7 @@ complik <- function(x, data, k=2, type=c("all","nearest"), pairlist,
                 if (is.factor(data[,i])) data0[,i] <- factor(data0[,i],levels=levels(data[,i]))
             }
         }
-        mydata[(1:nrow(data))+(ii-1)*nrow(data),] <- data0
+        mydata[seq_len(nrow(data))+(ii-1)*nrow(data),] <- data0
     }
     suppressWarnings(e0 <- estimate(x,data=mydata,estimator=estimator,missing=TRUE,messages=messages,
                                     hessian=!quick,
@@ -103,12 +103,12 @@ complik <- function(x, data, k=2, type=c("all","nearest"), pairlist,
         S <- score(e0,indiv=TRUE)
         nd <- nrow(data)
         block1 <- which((1:nd)%in%(rownames(S)))
-        blocks <- sapply(1:nblocks, function(x) 1:length(block1)+length(block1)*(x-1))
+        blocks <- sapply(seq_len(nblocks), function(x) seq_along(block1)+length(block1)*(x-1))
         if (nblocks==1) {
             Siid <- S
         } else {
             Siid <- matrix(0,nrow=length(block1),ncol=ncol(S))
-            for (j in 1:ncol(blocks)) {
+            for (j in seq_len(ncol(blocks))) {
                 Siid <- Siid+S[blocks[,j],]
             }
         }

--- a/R/estimate.default.R
+++ b/R/estimate.default.R
@@ -107,8 +107,8 @@ estimate <- function(x, ...) UseMethod("estimate")
 ##'
 ##' ## Marginalize
 ##' f <- function(p,data)
-##'   list(p0=lava:::expit(p["(Intercept)"] + p["z"]*data[,"z"]),
-##'        p1=lava:::expit(p["(Intercept)"] + p["x"] + p["z"]*data[,"z"]))
+##'   list(p0=expit(p["(Intercept)"] + p["z"]*data[,"z"]),
+##'        p1=expit(p["(Intercept)"] + p["x"] + p["z"]*data[,"z"]))
 ##' e <- estimate(g, f, average=TRUE)
 ##' e
 ##' estimate(e,diff)
@@ -117,7 +117,7 @@ estimate <- function(x, ...) UseMethod("estimate")
 ##' ## Clusters and subset (conditional marginal effects)
 ##' d$id <- rep(seq(nrow(d)/4),each=4)
 ##' estimate(g,function(p,data)
-##'          list(p0=lava:::expit(p[1] + p["z"]*data[,"z"])),
+##'          list(p0=expit(p[1] + p["z"]*data[,"z"])),
 ##'          subset=d$z>0, id=d$id, average=TRUE)
 ##'
 ##' ## More examples with clusters:
@@ -844,7 +844,7 @@ print.estimate <- function(x, type=0L, digits=4L, width=25L,
                     function(x) toString(x, width=width)))
     )
   if (!std.error) cc <- cc[, -2, drop=FALSE]
-  if (!p.value) cc[, -ncol(cc), drop=FALSE]
+  if (!p.value) cc <- cc[, -ncol(cc), drop=FALSE]
 
   sep.pos <- c()
   if (missing(sep.which) && !is.null(x$model.index)) {

--- a/R/estimate.formula.R
+++ b/R/estimate.formula.R
@@ -4,7 +4,7 @@ estimate.formula <- function(x, data, weights, family=stats::gaussian,
 
     cl <- match.call()
     if (lvm) {
-        cl[[1]] <- as.call(parse(text="lava:::estimate0"))[[1]]
+        cl[[1]] <- as.call(parse(text="estimate0"))[[1]]
         return(eval(cl,envir=parent.frame()))
     }
     if (missing(data)) {

--- a/R/gof.R
+++ b/R/gof.R
@@ -114,7 +114,7 @@ satmodel <- function(object,logLik=TRUE,data=model.frame(object),
               regr=FALSE,
               ...) {
     if (object$estimator=="gaussian" & logLik & !missing) {
-        if (class(object)[1]%in%c("multigroupfit","multigroup")) {
+        if (inherits(object, c("multigroupfit","multigroup"))) {
 
             ll <- structure(0,nall=0,nobs=0,df=0,class="logLik")
             for (i in seq_len(Model(object)$ngroup)) {
@@ -245,7 +245,7 @@ condition <- function(x) {
 ##' @export
 gof.lvmfit <- function(object,chisq=FALSE,level=0.90,rmsea.threshold=0.05,all=FALSE,...) {
     n <- object$data$n
-    if (class(object)[1]=="multigroupfit") n <- sum(unlist(lapply(object$model$data,nrow)))
+    if (inherits(object, "multigroupfit")) n <- sum(unlist(lapply(object$model$data,nrow)))
     loglik <- logLik(object,...)
 
     df <- attributes(loglik)$df
@@ -261,7 +261,7 @@ gof.lvmfit <- function(object,chisq=FALSE,level=0.90,rmsea.threshold=0.05,all=FA
     minSV <- attr(S,"minSV")
     condnum <- tryCatch(condition(vcov(object)),error=function(...) NULL)
 
-    if (((object$estimator=="gaussian" & class(object)[1]!="lvm.missing") | chisq) & length(xconstrain)==0 ) {
+    if (((object$estimator=="gaussian" & !inherits(object, "lvm.missing")) | chisq) & length(xconstrain)==0 ) {
         res <- list(fit=compare(object), n=n, logLik=loglik, BIC=myBIC, AIC=myAIC)
         q <- res$fit$statistic
         qdf <- res$fit$parameter

--- a/R/mixture.R
+++ b/R/mixture.R
@@ -238,7 +238,7 @@ mixture <- function(x, data, k=length(x),
         myp <- lapply(ParPos,function(x) p[x])
         K <- length(myp)
         prob <- p[seq(Npar+1,Npar+K-1)]; prob <- c(prob,1-sum(prob))
-        logff <- sapply(1:length(myp), function(j) (logLik(mg$lvm[[j]],p=myp[[j]],data=data,indiv=TRUE,model=MODEL)))
+        logff <- sapply(seq_along(myp), function(j) (logLik(mg$lvm[[j]],p=myp[[j]],data=data,indiv=TRUE,model=MODEL)))
         ## logff <- sapply(1:length(myp),
         ##              function(j) -normal_objective.lvm(mg$lvm[[j]],p=myp[[j]],data=data,indiv=TRUE))
         logplogff <- t(apply(logff,1, function(y) y+log(prob)))
@@ -276,7 +276,7 @@ mixture <- function(x, data, k=length(x),
         ## zmax <- apply(logff,1,max)
         ## ffz <- apply(logff,2,function(x) exp(x-zmax))
         ## sffz <- rowSums(ffz)
-        D <- lapply(1:length(myp), function(j) {
+        D <- lapply(seq_along(myp), function(j) {
             ## K <- ffz[,j]/sffz
             val <- score(mg$lvm[[j]],p=myp[[j]],data=data,indiv=TRUE,model=MODEL)
             apply(val,2,function(x) x*gamma[,j])
@@ -295,7 +295,7 @@ mixture <- function(x, data, k=length(x),
             p[constrained] <- exp(p[constrained])
         }
         myp <- lapply(ParPos,function(x) p[x])
-        D <- lapply(1:length(myp), function(j) {
+        D <- lapply(seq_along(myp), function(j) {
             ## K <- ffz[,j]/sffz
             val <- score(mg$lvm[[j]],p=myp[[j]],data=data,indiv=TRUE,model=MODEL)
             apply(val,2,function(x) x*gamma[,j])
@@ -479,7 +479,7 @@ summary.lvm.mixture <- function(object,type=0,labels=0,...) {
     mm <- object$multigroup$lvm
     p <- coef(object,list=TRUE)
     p0 <- coef(object,prob=FALSE)
-    myp <- modelPar(object$multigroup,1:length(p0))$p
+    myp <- modelPar(object$multigroup,seq_along(p0))$p
     coefs <- list()
     ncluster <- c()
     Coefs <- matrix(NA,ncol=4,nrow=length(parname))
@@ -488,7 +488,7 @@ summary.lvm.mixture <- function(object,type=0,labels=0,...) {
     Variable  <- rep(NA,length(parname))
     From  <- rep(NA,length(parname))
     Latent <- c()
-    for (i in 1:length(mm)) {
+    for (i in seq_along(mm)) {
         cc.idx <- order(coef(mm[[i]],p=seq_along(p[[i]]),type=2)[,1])
 
         cc <- coef(mm[[i]],p=p[[i]],vcov=vcov(object)[myp[[i]],myp[[i]]],data=NULL,labels=labels,type=2)
@@ -526,7 +526,7 @@ print.summary.lvm.mixture <- function(x,...) {
         print(CoefMat(cc), quote=FALSE)
         return(invisible())
     }
-    for (i in 1:length(x$coef)) {
+    for (i in seq_along(x$coef)) {
         cat("Cluster ",i," (n=",x$ncluster[i],", Prior=", formatC(x$prob[i]),"):\n",sep="")
         cat(rep("-",50),"\n",sep="")
         print(x$coef[[i]], quote=FALSE)

--- a/R/rbind.Surv.R
+++ b/R/rbind.Surv.R
@@ -28,10 +28,10 @@ rbind.Surv <- function(...)
   nrow <- unlist(lapply(dots,nrow))
   cnrow <- c(0,cumsum(nrow))
   M <- matrix(ncol=ncol,nrow=sum(nrow))
-  for (i in 1:length(dots)) {
+  for (i in seq_along(dots)) {
     M[(cnrow[i]+1):cnrow[i+1],] <- dots[[i]]
   }
-  x <- c(); for (i in 1:ncol(M)) x <- c(x,list(M[,i]))
+  x <- c(); for (i in seq_len(ncol(M))) x <- c(x,list(M[,i]))
   x <- c(x,list(type=type))
   do.call(survival::Surv, x)
 } 


### PR DESCRIPTION
- Fix print.estimate ignoring p.value=FALSE (missing assignment)
- Replace unsafe 1:length()/1:nrow() with seq_along()/seq_len() (13 locations)
- Replace class(x)[1] == with inherits() in gof.R (3 locations)
- Remove unnecessary lava:::expit in examples (already exported)
